### PR TITLE
Using Catch2 instead of Boost.Test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+rsrc/*.txt eol=lf
 rsrc/subdir/*.txt eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+rsrc/subdir/*.txt eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,9 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # set the project name
-project(mrc VERSION 1.3.12)
+project(mrc VERSION 1.3.11)
 
 include(CTest)
-include(FindFilesystem)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # set the project name
-project(mrc VERSION 1.3.11)
+project(mrc VERSION 1.3.12)
 
 include(CTest)
 include(FindFilesystem)
@@ -63,7 +63,19 @@ if(WIN32)
 	message(STATUS "Using COFF spec: ${COFF_SPEC}")
 endif()
 
-find_package(libmcfp 1.2.4)
+find_package(libmcfp 1.2.4 QUIET)
+
+if(NOT libmcfp_FOUND)
+	include(FetchContent)
+
+	FetchContent_Declare(
+		libmcfp
+		GIT_REPOSITORY https://github.com/mhekkel/libmcfp
+		GIT_TAG v1.2.4
+	)
+
+	FetchContent_MakeAvailable(libmcfp)
+endif()
 
 include(VersionString)
 write_version_header(${PROJECT_SOURCE_DIR}/src/)
@@ -80,7 +92,19 @@ target_link_libraries(mrc std::filesystem libmcfp::libmcfp)
 target_link_libraries(mrc-bootstrap std::filesystem libmcfp::libmcfp)
 
 if(BUILD_TESTING)
-	find_package(Boost REQUIRED)
+	find_package(Catch2 3 QUIET)
+
+	if(NOT Catch2_FOUND)
+		Include(FetchContent)
+
+		FetchContent_Declare(
+			Catch2
+			GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+			GIT_TAG v3.4.0 # or a later release
+		)
+
+		FetchContent_MakeAvailable(Catch2)
+	endif()
 
 	file(GLOB UNIT_TEST_RSRC LIST_DIRECTORIES true ${PROJECT_SOURCE_DIR}/rsrc/*)
 
@@ -88,9 +112,9 @@ if(BUILD_TESTING)
 		COMMAND $<TARGET_FILE:mrc-bootstrap> -o mrc-unit-test-rsrc.obj ${UNIT_TEST_RSRC} ${COFF_SPEC}
 		DEPENDS ${UNIT_TEST_RSRC} mrc-bootstrap
 	)
-	
+
 	add_executable(mrc-unit-test ${PROJECT_SOURCE_DIR}/src/mrc-unit-test.cpp ${CMAKE_BINARY_DIR}/mrc-unit-test-rsrc.obj)
-	target_link_libraries(mrc-unit-test Boost::boost)
+	target_link_libraries(mrc-unit-test Catch2::Catch2WithMain)
 
 	add_test(NAME unit-test COMMAND $<TARGET_FILE:mrc-unit-test> WORKING_DIRECTORY .)
 endif()

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+Version 1.3.12
+- Moved from Boost.Test to Catch2 for unit testing
+
 Version 1.3.11
 - Remove libmcfp as submodule
 

--- a/changelog
+++ b/changelog
@@ -1,8 +1,7 @@
-Version 1.3.12
-- Moved from Boost.Test to Catch2 for unit testing
-
 Version 1.3.11
 - Remove libmcfp as submodule
+- Moved from Boost.Test to Catch2 for unit testing
+- Using FetchContent for dependencies
 
 Version 1.3.10
 - Check cmake version before trying to write dependency file commands

--- a/src/mrc-unit-test.cpp
+++ b/src/mrc-unit-test.cpp
@@ -1,31 +1,33 @@
-#define BOOST_TEST_MODULE MRC_Test
-#include <boost/test/included/unit_test.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "mrsrc.h"
 
-BOOST_AUTO_TEST_CASE(test_1)
+#include <iostream>
+#include <set>
+
+TEST_CASE("test_1", "test_1")
 {
 	mrsrc::rsrc r1("resource-1.txt");
 
-	BOOST_ASSERT((bool)r1);
+	REQUIRE((bool)r1);
 
-	BOOST_TEST(r1.data() != nullptr);
-	BOOST_TEST(r1.size() == 50);
+	REQUIRE(r1.data() != nullptr);
+	REQUIRE(r1.size() == 50);
 
 	int r = std::memcmp(r1.data(), R"(This is the first line
 And this is the second line)", r1.size());
 
-	BOOST_TEST(r == 0);
+	REQUIRE(r == 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_2)
+TEST_CASE("test_2", "test_2")
 {
 	mrsrc::rsrc r2("resource-2.txt");
 
-	BOOST_ASSERT((bool)r2);
+	REQUIRE((bool)r2);
 
-	BOOST_TEST(r2.data() != nullptr);
-	BOOST_TEST(r2.size() == 102);
+	REQUIRE(r2.data() != nullptr);
+	REQUIRE(r2.size() == 102);
 /*
 		const char16_t* t = u"\xfeffThis is the first line\
 And this is the second line";
@@ -33,40 +35,40 @@ And this is the second line";
 
 		int r = std::memcmp(r2.data(), (char*)t, r2.size());
 
-		BOOST_TEST(r == 0);
+		REQUIRE(r == 0);
 */
 }
 
-BOOST_AUTO_TEST_CASE(test_3)
+TEST_CASE("test_3", "test_3")
 {
 	mrsrc::streambuf buf("resource-1.txt");
 	std::istream is(&buf);
 
 	std::string line;
-	BOOST_TEST((bool)std::getline(is, line));
-	BOOST_TEST(line == "This is the first line");
-	BOOST_TEST((bool)std::getline(is, line));
-	BOOST_TEST(line == "And this is the second line");
-	BOOST_TEST(not std::getline(is, line));
+	REQUIRE((bool)std::getline(is, line));
+	REQUIRE(line == "This is the first line");
+	REQUIRE((bool)std::getline(is, line));
+	REQUIRE(line == "And this is the second line");
+	REQUIRE(not std::getline(is, line));
 }
 
-BOOST_AUTO_TEST_CASE(test_4)
+TEST_CASE("test_4", "test_4")
 {
 	mrsrc::istream is("resource-1.txt");
 
 	std::string line;
-	BOOST_TEST((bool)std::getline(is, line));
-	BOOST_TEST(line == "This is the first line");
-	BOOST_TEST((bool)std::getline(is, line));
-	BOOST_TEST(line == "And this is the second line");
-	BOOST_TEST(not std::getline(is, line));
+	REQUIRE((bool)std::getline(is, line));
+	REQUIRE(line == "This is the first line");
+	REQUIRE((bool)std::getline(is, line));
+	REQUIRE(line == "And this is the second line");
+	REQUIRE(not std::getline(is, line));
 }
 
-BOOST_AUTO_TEST_CASE(test_10)
+TEST_CASE("test_10", "test_10")
 {
 	mrsrc::rsrc r0("");
 
-	BOOST_TEST(std::distance(r0.begin(), r0.end()) == 3);
+	REQUIRE(std::distance(r0.begin(), r0.end()) == 3);
 
 	std::set<std::string> found;
 	for (auto& r1: r0)
@@ -74,7 +76,7 @@ BOOST_AUTO_TEST_CASE(test_10)
 
 	std::set<std::string> kTest{"resource-1.txt", "resource-2.txt", "subdir"};
 
-	BOOST_TEST(found == kTest);
+	REQUIRE(found == kTest);
 
 	if (found != kTest)
 	{
@@ -83,48 +85,48 @@ BOOST_AUTO_TEST_CASE(test_10)
 	}
 }
 
-BOOST_AUTO_TEST_CASE(test_11)
+TEST_CASE("test_11", "test_11")
 {
 	mrsrc::rsrc r0("subdir/resource-3.txt");
 
-	BOOST_TEST((bool)r0);
+	REQUIRE((bool)r0);
 
 	mrsrc::istream is(r0);
 	std::string line;
-	BOOST_TEST((bool)std::getline(is, line));
-	BOOST_TEST(line == "Dit is resource 3");
+	REQUIRE((bool)std::getline(is, line));
+	REQUIRE(line == "Dit is resource 3");
 }
 
-BOOST_AUTO_TEST_CASE(test_12)
+TEST_CASE("test_12", "test_12")
 {
 	mrsrc::rsrc r0("subdir/subsubdir/resource-4.txt");
 
-	BOOST_TEST((bool)r0);
+	REQUIRE((bool)r0);
 
 	mrsrc::istream is(r0);
 	std::string line;
-	BOOST_TEST((bool)std::getline(is, line));
-	BOOST_TEST(line == "Dit is resource 4");
+	REQUIRE((bool)std::getline(is, line));
+	REQUIRE(line == "Dit is resource 4");
 }
 
-BOOST_AUTO_TEST_CASE(test_13)
+TEST_CASE("test_13", "test_13")
 {
 	mrsrc::istream ri("subdir/resource-3.txt");
 
-	BOOST_TEST((bool)ri);
-	BOOST_CHECK_EQUAL(ri.eof(), false);
+	REQUIRE((bool)ri);
+	REQUIRE(ri.eof() == false);
 
 	std::string line;
-	BOOST_TEST((bool)std::getline(ri, line));
-	BOOST_TEST(line == "Dit is resource 3");
-	BOOST_CHECK_EQUAL(ri.eof(), true);
+	REQUIRE((bool)std::getline(ri, line));
+	REQUIRE(line == "Dit is resource 3");
+	REQUIRE(ri.eof() == true);
 }
 
-BOOST_AUTO_TEST_CASE(test_14)
+TEST_CASE("test_14", "test_14")
 {
 	mrsrc::istream ri("resource-5.txt");
 
-	BOOST_CHECK_EQUAL((bool)ri, false);
-	BOOST_CHECK_EQUAL(ri.bad(), true);
+	REQUIRE((bool)ri == false);
+	REQUIRE(ri.bad() == true);
 }
 


### PR DESCRIPTION
Start using Catch2 instead of Boost.Test to reduce huge dependencies