### PR TITLE
Add support for GNU/Hurd

### DIFF
--- a/src/mrc.cpp
+++ b/src/mrc.cpp
@@ -1221,6 +1221,9 @@ int main(int argc, char *argv[])
 		elfc.elf_abi = ELFOSABI_FREEBSD;
 		int r = strlen(argv[0]);
 		strcpy(exePath, argv[0]);
+# elif __GNU__
+		elfc.elf_abi = ELFOSABI_GNU;
+		int r = readlink("/proc/self/exe", exePath, PATH_MAX);
 # else
 #  error "Unsupported OS, sorry..."
 # endif


### PR DESCRIPTION
GNU/Hurd is a POSIX ELF OS, so
- use the right ABI tag for it
- use `/proc/self/exe` to find the `mrc` process itself